### PR TITLE
Adding Gemini Typescript SDK support methods

### DIFF
--- a/src/typescript/constants/common.ts
+++ b/src/typescript/constants/common.ts
@@ -5,6 +5,7 @@ import { AnthropicFunctions, AnthropicFunctionNames } from './anthropic';
 import { PgFunctionNames, PgFunctions } from './pg';
 import { ChromadbFunctionNames, ChromadbFunctions } from './chroma';
 import { CohereFunctionNames, CohereFunctions } from './cohere';
+import { GeminiFunctionNames, GeminiFunctions } from './gemini';
 import { GroqFunctionNames, GroqFunctions } from './groq';
 import { LlamaIndexFunctionNames, LlamaIndexFunctions } from './llamaindex';
 import { OpenAIFunctionNames, OpenAIFunctions } from './openai';
@@ -27,6 +28,7 @@ export const Vendors = {
   OPENAI: 'openai',
   COHERE: 'cohere',
   ANTHROPIC: 'anthropic',
+  GEMINI: 'gemini',
   GROQ: 'groq',
   PINECONE: 'pinecone',
   LLAMAINDEX: 'llamaindex',
@@ -53,6 +55,7 @@ interface VendorInstrumentationFunctions {
   openai: OpenAIFunctions[];
   cohere: CohereFunctions[];
   anthropic: AnthropicFunctions[];
+  gemini: GeminiFunctions[];
   groq: GroqFunctions[];
   pinecone: PineConeFunctions[];
   llamaindex: LlamaIndexFunctions[];
@@ -73,6 +76,7 @@ export const TracedFunctionsByVendor: VendorTracedFunctions = {
   pg: PgFunctionNames,
   chromadb: ChromadbFunctionNames,
   cohere: CohereFunctionNames,
+  gemini: GeminiFunctionNames,
   groq: GroqFunctionNames,
   llamaindex: LlamaIndexFunctionNames,
   openai: OpenAIFunctionNames,

--- a/src/typescript/constants/gemini.ts
+++ b/src/typescript/constants/gemini.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Scale3 Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const APIS = {
+	GENERATE_CONTENT: {
+		METHOD: "gemini.GenerativeModel.generateContent",
+  },
+	GENERATE_CONTENT_STREAM: {
+		METHOD: "gemini.GenerativeModel.generateContentStream",
+	},
+} as const;
+export type GeminiFunctions = typeof APIS[keyof typeof APIS]['METHOD']
+export const GeminiFunctionNames: GeminiFunctions[] = Object.values(APIS).map((api) => api.METHOD)

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -6,6 +6,7 @@ import { APIS as AnthropicAPIS } from "./constants/anthropic";
 import { APIS as PgAPIS } from "./constants/pg";
 import { APIS as ChromadbAPIS } from "./constants/chroma";
 import { APIS as CohereAPIS } from "./constants/cohere";
+import { APIS as GeminiAPIS } from "./constants/gemini";
 import { APIS as GroqAPIS } from "./constants/groq";
 import { APIS as LlamaIndexAPIS } from "./constants/llamaindex";
 import { APIS as OpenAIAPIs } from "./constants/openai";
@@ -42,6 +43,7 @@ const APIS = {
   pg: PgAPIS,
   chromadb: ChromadbAPIS,
   cohere: CohereAPIS,
+  gemini: GeminiAPIS,
   groq: GroqAPIS,
   llamaindex: LlamaIndexAPIS,
   openai: OpenAIAPIs,

--- a/src/typescript/package-lock.json
+++ b/src/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@langtrase/trace-attributes",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@langtrase/trace-attributes",
-            "version": "7.1.1",
+            "version": "7.2.0",
             "license": "MIT",
             "dependencies": {
                 "js-tiktoken": "^1.0.14",

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@langtrase/trace-attributes",
-    "version": "7.1.2",
+    "version": "7.2.0",
     "description": "LangTrace - Trace Attributes",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
# Description

Adding Gemini methods that are to be supported by Langtrace Typescript SDK.

# Checklist for EVERY version bump:

- [ ] Ran [generate_python.sh](../scripts/generate_python.sh) to generate python models. (Check [README.md](../README.md) for instructions)
- [ ] Ran [generate_typescript.sh](../scripts/generate_typescript.sh) to generate typescript models. (Check [README.md](../README.md) for instructions)
- [ ] Ran `black .` to format the python code.
- [ ] Updated version in [setup.py](../setup.py) for python package.
- [ ] Updated version in [package.json](../src/typescript/package.json) for typescript package.
- [ ] Updated the required version of `trace-attributes` in python SDK dependency [project.toml](https://github.com/Scale3-Labs/langtrace-python-sdk/blob/main/pyproject.toml) file.
- [ ] Updated the required version of `@langtrase/trace-attributes` in typescript SDK dependency [package.json](https://github.com/Scale3-Labs/langtrace-typescript-sdk/blob/main/package.json).
