### PR TITLE
fix: weaviate create collection tracing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="trace-attributes",  # Choose a unique name for PyPI
-    version="7.0.2",
+    version="7.0.3",
     author="Karthik Kalyanaraman",
     author_email="karthik@scale3labs.com",
     description="LangTrace - Trace Attributes",

--- a/src/python/langtrace/trace_attributes/__init__.py
+++ b/src/python/langtrace/trace_attributes/__init__.py
@@ -144,7 +144,7 @@ class WeaviateMethods(Enum):
     QUERY_NEAR_OBJECT = "weaviate.collections.queries.near_object"
     QUERY_NEAR_TEXT = "weaviate.collections.queries.near_text"
     QUERY_NEAR_VECTOR = "weaviate.collections.queries.near_vector"
-    COLLECTIONS_OPERATIONS = "weaviate.collections.collections"
+    COLLECTIONS_OPERATIONS = "weaviate.collections.collections.sync"
 
 
 class VendorType(Enum):


### PR DESCRIPTION
# Description

Fixing weaviate create collection method module

# Checklist for EVERY version bump:

- [ ] Ran [generate_python.sh](../scripts/generate_python.sh) to generate python models. (Check [README.md](../README.md) for instructions)
- [ ] Ran [generate_typescript.sh](../scripts/generate_typescript.sh) to generate typescript models. (Check [README.md](../README.md) for instructions)
- [x] Ran `black .` to format the python code.
- [x] Updated version in [setup.py](../setup.py) for python package.
- [ ] Updated version in [package.json](../src/typescript/package.json) for typescript package.
- [x] Updated the required version of `trace-attributes` in python SDK dependency [project.toml](https://github.com/Scale3-Labs/langtrace-python-sdk/blob/main/pyproject.toml) file.
- [ ] Updated the required version of `@langtrase/trace-attributes` in typescript SDK dependency [package.json](https://github.com/Scale3-Labs/langtrace-typescript-sdk/blob/main/package.json).
